### PR TITLE
Added x-line into both Katakana and Hiragana table

### DIFF
--- a/hiragana.go
+++ b/hiragana.go
@@ -3,6 +3,7 @@ package kana
 // HiraganaTable maps romaji to hiragana
 var HiraganaTable = `	a	i	u	e	o	n
 	あ	い	う	え	お	ん
+x	ぁ	ぃ	ぅ	ぇ	ぉ
 k	か	き	く	け	こ
 ky	きゃ		きゅ		きょ
 s	さ		す	せ	そ

--- a/kana_test.go
+++ b/kana_test.go
@@ -19,6 +19,7 @@ var hiraganaToRomajiTests = []kanaTest{
 	{"んい", "nni"},
 	{"はんのう", "hannnou"},
 	{"はんおう", "hannou"},
+	{"あうでぃ", "audexi"},
 }
 
 func TestHiraganaToRomaji(t *testing.T) {
@@ -39,6 +40,7 @@ var katakanaToRomajiTests = []kanaTest{
 	{"ＣＤプレーヤー", "ＣＤpure-ya-"},
 	{"オーバーヘッドキック", "o-ba-heddokikku"},
 	{"ハンノウ", "hannnou"},
+	{"アウディ", "audexi"},
 }
 
 func TestKatakanaToRomaji(t *testing.T) {

--- a/katakana.go
+++ b/katakana.go
@@ -3,6 +3,7 @@ package kana
 // KatakanaTable maps romaji to katakana
 var KatakanaTable = `	a	i	u	e	o	n
 	ア	イ	ウ	エ	オ	ン
+x	ァ	ィ	ゥ	ェ	ォ
 k	カ	キ	ク	ケ	コ
 ky	キャ		キュ		キョ
 s	サ		ス	セ	ソ


### PR DESCRIPTION
I fixed the following. Also added testing together with this pr. let easily refer to it.

```
=== RUN TestHiraganaToRomaji
--- FAIL: TestHiraganaToRomaji (0.00 seconds)
        kana_test.go:28: KanaToRomaji("あうでぃ") = "audeぃ", want "audexi"
=== RUN TestKatakanaToRomaji
--- FAIL: TestKatakanaToRomaji (0.00 seconds)
        kana_test.go:49: KanaToRomaji("アウディ") = "audeィ", want "audexi"
```